### PR TITLE
#4736 (1/2) Create components page to act as a playground for new tailwind components

### DIFF
--- a/cl/simple_pages/templates/components.html
+++ b/cl/simple_pages/templates/components.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block title %}Components Library - CourtListener.com{% endblock %}
+
+{% block content %}
+<h1>Components Library</h1>
+{% endblock %}

--- a/cl/simple_pages/urls.py
+++ b/cl/simple_pages/urls.py
@@ -6,6 +6,7 @@ from cl.simple_pages.views import (
     advanced_search,
     alert_help,
     broken_email_help,
+    components,
     contact,
     contact_thanks,
     contribute,
@@ -78,6 +79,7 @@ urlpatterns = [
     ),
     path("terms/v/<int:v>/", old_terms, name="old_terms"),  # type: ignore[arg-type]
     path("terms/", latest_terms, name="terms"),  # type: ignore[arg-type]
+    path("components/", components, name="components"),  # type: ignore[arg-type]
     # Robots
     path(
         "robots.txt",

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -474,6 +474,10 @@ async def validate_for_wot(request: HttpRequest) -> HttpResponse:
     return HttpResponse("bcb982d1e23b7091d5cf4e46826c8fc0")
 
 
+async def components(request: HttpRequest) -> HttpResponse:
+    return TemplateResponse(request, "components.html", {"private": True})
+
+
 async def ratelimited(
     request: HttpRequest, exception: Exception
 ) -> HttpResponse:


### PR DESCRIPTION
Pulls key elements from [#4800](https://github.com/freelawproject/courtlistener/pull/4800) to create a new basic components page